### PR TITLE
feat(#42): FEATURE 1.1.3 — Immutable DeFi value objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,141 @@ pytest tests/blockchain/ -v
 
 ---
 
+### DeFi Bounded Context — Foundation (`app/services/defi/`)
+
+**Epic 1 / Task 1.1 — [issues #9, #16]**
+
+Establishes the isolated `services/defi/` bounded context inside the FastAPI monorepo following the same DDD layering already adopted in `services/blockchain/ethereum/`. No DeFi logic leaks outside this context.
+
+#### Package structure
+
+```
+app/services/defi/
+├── domain/
+│   ├── entities/          # Pydantic v2 domain entities (see below)
+│   ├── value_objects/     # Frozen dataclasses (see FEATURE 1.1.3 below)
+│   ├── interfaces/        # ABCs — no concrete implementation in the domain
+│   └── exceptions.py      # DeFiError hierarchy
+├── application/
+│   └── quote_service.py   # QuoteService — orchestrates without infra dependencies
+├── infrastructure/
+│   ├── config/settings.py # DeFiSettings (DEFI_ prefix, separate from EthereumSettings)
+│   ├── cache/
+│   ├── market_data/
+│   ├── persistence/
+│   ├── workers/
+│   ├── indexer/
+│   ├── compliance/
+│   └── audit/
+└── api/
+    ├── routers/           # FastAPI router — /v1/defi/quote
+    ├── schemas/           # Pydantic v2 request/response schemas
+    └── middleware/
+```
+
+#### Domain entities (`domain/entities/`)
+
+| Class | Description |
+|-------|-------------|
+| `Token` | ERC20 token descriptor with address and chain validation |
+| `Pool` | Liquidity pool with pair addresses, fee tier, and TVL |
+| `Position` | LP or lending position tied to a wallet and pool |
+| `Protocol` | DeFi protocol descriptor (name, version, chain) |
+| `Quote` | Swap quote result (amount in/out, slippage, price impact) |
+| `WalletSession` | Non-custodial session reference — holds address only, never private key |
+| `UnsignedTransaction` | EVM transaction payload ready for client-side signing; signing fields (v/r/s) are rejected on construction |
+| `MarketIndex` | On-chain index snapshot (symbol, value, timestamp) |
+| `ResearchReport` | Impersonal research record (title, summary, price target) |
+
+All entities use Pydantic v2 validation. `WalletSession` and `UnsignedTransaction` enforce the non-custodial invariant at the model level.
+
+#### Domain interfaces (`domain/interfaces/`)
+
+| Interface | Description |
+|-----------|-------------|
+| `ITokenRepository` | Port for token lookup by address and chain |
+| `IPoolRepository` | Port for pool discovery and TVL queries |
+| `IPositionRepository` | Port for user position reads and writes |
+| `IPriceOracle` | Port for spot and historical price feeds |
+| `ISwapService` | Port for quote computation and swap execution |
+
+All interfaces are abstract base classes (`ABC`) with no concrete implementation in the domain layer.
+
+#### Domain exceptions (`domain/exceptions.py`)
+
+All exceptions inherit from `DeFiError` (the bounded-context base):
+
+`TokenNotFoundError`, `PoolNotFoundError`, `NoPoolsForPairError`, `InsufficientLiquidityError`, `SlippageExceededError`, `ProtocolNotSupportedError`, `PriceUnavailableError`, `PositionNotFoundError`.
+
+---
+
+### DeFi Value Objects — FEATURE 1.1.3 (`app/services/defi/domain/value_objects/`)
+
+**[issue #42]** — Five new immutable value objects added to the DeFi domain layer. All are `@dataclass(frozen=True)`: mutation raises `FrozenInstanceError` at runtime. Plug-and-play addition — existing value objects (`Address`, `Price`, `Slippage`, `TokenAmount`) are untouched.
+
+| Class | File | Validation |
+|-------|------|------------|
+| `TokenAddress` | `token_address.py` | EIP-55 checksum via `web3.Web3.to_checksum_address()`; requires `0x` prefix; normalises to checksummed form regardless of input case |
+| `ChainId` | `chain_id.py` | Validated against the supported set `{1, 137, 42161, 8453}`; any other value raises `ValueError` with the list of supported chains |
+| `FiatPrice` | `fiat_price.py` | `amount >= 0`; `currency` must be a 3-letter alphabetic ISO 4217 code (normalised to uppercase) |
+| `CryptoAmount` | `crypto_amount.py` | `raw >= 0`; `decimals ∈ [0, 18]`; exposes `as_decimal` property (`Decimal(raw) / 10**decimals`) |
+| `TxHash` | `tx_hash.py` | Must match `^0x[0-9a-fA-F]{64}$`; stored lowercased |
+
+**Supported chains for `ChainId`:**
+
+| Chain ID | Network |
+|----------|---------|
+| 1 | Ethereum Mainnet |
+| 137 | Polygon |
+| 42161 | Arbitrum One |
+| 8453 | Base |
+
+**Usage example:**
+
+```python
+from app.services.defi.domain.value_objects import (
+    TokenAddress, ChainId, FiatPrice, CryptoAmount, TxHash
+)
+from decimal import Decimal
+
+# TokenAddress — normalises to EIP-55 checksum
+addr = TokenAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+# addr.value == "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+# ChainId — rejects unsupported networks
+chain = ChainId(137)   # Polygon — OK
+# ChainId(56)          # raises ValueError: Unsupported chain_id 56
+
+# FiatPrice — ISO 4217 currency
+price = FiatPrice(amount=Decimal("3500.00"), currency="usd")
+# price.currency == "USD"
+
+# CryptoAmount — smallest-unit representation
+one_eth = CryptoAmount(raw=10**18, decimals=18)
+# one_eth.as_decimal == Decimal("1")
+
+# TxHash — 32-byte transaction identifier
+tx = TxHash("0x" + "ab" * 32)
+# tx.value is lowercased
+
+# Immutability guaranteed
+from dataclasses import FrozenInstanceError
+try:
+    addr.value = "0x..."   # raises FrozenInstanceError
+except FrozenInstanceError:
+    pass
+```
+
+#### Running the value objects tests
+
+```bash
+pytest tests/defi/domain/test_value_objects.py -v
+```
+
+70 unit tests covering: valid construction, EIP-55 normalisation, chain ID rejection, currency normalisation, `FrozenInstanceError` on mutation, and all invalid-input edge cases.
+
+---
+
 ## Regulatory boundaries
 
 Zero financial license cost is not zero compliance. As a technology company the platform maintains:

--- a/app/services/defi/domain/value_objects/__init__.py
+++ b/app/services/defi/domain/value_objects/__init__.py
@@ -1,6 +1,21 @@
 from .address import Address
+from .chain_id import ChainId
+from .crypto_amount import CryptoAmount
+from .fiat_price import FiatPrice
 from .price import Price
 from .slippage import Slippage
+from .token_address import TokenAddress
 from .token_amount import TokenAmount
+from .tx_hash import TxHash
 
-__all__ = ["Address", "Price", "Slippage", "TokenAmount"]
+__all__ = [
+    "Address",
+    "ChainId",
+    "CryptoAmount",
+    "FiatPrice",
+    "Price",
+    "Slippage",
+    "TokenAddress",
+    "TokenAmount",
+    "TxHash",
+]

--- a/app/services/defi/domain/value_objects/chain_id.py
+++ b/app/services/defi/domain/value_objects/chain_id.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+SUPPORTED_CHAIN_IDS: frozenset[int] = frozenset({
+    1,      # Ethereum Mainnet
+    137,    # Polygon
+    42161,  # Arbitrum One
+    8453,   # Base
+})
+
+
+@dataclass(frozen=True)
+class ChainId:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value not in SUPPORTED_CHAIN_IDS:
+            raise ValueError(
+                f"Unsupported chain_id {self.value}. "
+                f"Supported chains: {sorted(SUPPORTED_CHAIN_IDS)}"
+            )
+
+    def __int__(self) -> int:
+        return self.value
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/app/services/defi/domain/value_objects/crypto_amount.py
+++ b/app/services/defi/domain/value_objects/crypto_amount.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class CryptoAmount:
+    raw: int       # smallest unit (e.g. wei, satoshi)
+    decimals: int  # token decimal places [0, 18]
+
+    def __post_init__(self) -> None:
+        if self.raw < 0:
+            raise ValueError("CryptoAmount.raw must be >= 0")
+        if not (0 <= self.decimals <= 18):
+            raise ValueError(
+                f"CryptoAmount.decimals must be in [0, 18], got {self.decimals}"
+            )
+
+    @property
+    def as_decimal(self) -> Decimal:
+        return Decimal(self.raw) / Decimal(10 ** self.decimals)
+
+    def __repr__(self) -> str:
+        return f"CryptoAmount({self.as_decimal})"

--- a/app/services/defi/domain/value_objects/fiat_price.py
+++ b/app/services/defi/domain/value_objects/fiat_price.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class FiatPrice:
+    amount: Decimal
+    currency: str  # ISO 4217 (e.g. "USD", "EUR", "BRL")
+
+    def __post_init__(self) -> None:
+        if self.amount < Decimal(0):
+            raise ValueError("FiatPrice.amount must be >= 0")
+        normalized = self.currency.strip().upper()
+        if len(normalized) != 3 or not normalized.isalpha():
+            raise ValueError(
+                f"FiatPrice.currency must be a 3-letter ISO 4217 code, got {self.currency!r}"
+            )
+        object.__setattr__(self, "currency", normalized)
+
+    def __str__(self) -> str:
+        return f"{self.amount} {self.currency}"

--- a/app/services/defi/domain/value_objects/token_address.py
+++ b/app/services/defi/domain/value_objects/token_address.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from web3 import Web3
+
+
+@dataclass(frozen=True)
+class TokenAddress:
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str) or not self.value.startswith("0x"):
+            raise ValueError(f"Invalid token address: {self.value!r}")
+        try:
+            checksummed = Web3.to_checksum_address(self.value)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"Invalid token address: {self.value!r}") from exc
+        object.__setattr__(self, "value", checksummed)
+
+    def __str__(self) -> str:
+        return self.value

--- a/app/services/defi/domain/value_objects/tx_hash.py
+++ b/app/services/defi/domain/value_objects/tx_hash.py
@@ -1,0 +1,20 @@
+import re
+from dataclasses import dataclass
+
+_TX_HASH_PATTERN = re.compile(r"^0x[0-9a-fA-F]{64}$")
+
+
+@dataclass(frozen=True)
+class TxHash:
+    value: str
+
+    def __post_init__(self) -> None:
+        if not _TX_HASH_PATTERN.match(self.value):
+            raise ValueError(
+                f"Invalid transaction hash: {self.value!r}. "
+                "Expected 0x followed by 64 hex characters."
+            )
+        object.__setattr__(self, "value", self.value.lower())
+
+    def __str__(self) -> str:
+        return self.value

--- a/tests/defi/domain/test_value_objects.py
+++ b/tests/defi/domain/test_value_objects.py
@@ -1,0 +1,338 @@
+"""Unit tests for FEATURE 1.1.3 — Immutable value objects (issue #42).
+
+Covers: TokenAddress, ChainId, FiatPrice, CryptoAmount, TxHash.
+DoD:
+- All value objects are frozen (FrozenInstanceError on mutation).
+- TokenAddress rejects invalid addresses.
+- ChainId rejects unsupported chains.
+- Invalid cases are fully covered.
+"""
+from dataclasses import FrozenInstanceError
+from decimal import Decimal
+
+import pytest
+
+from app.services.defi.domain.value_objects import (
+    ChainId,
+    CryptoAmount,
+    FiatPrice,
+    TokenAddress,
+    TxHash,
+)
+from app.services.defi.domain.value_objects.chain_id import SUPPORTED_CHAIN_IDS
+
+# ---------------------------------------------------------------------------
+# TokenAddress
+# ---------------------------------------------------------------------------
+
+VALID_ADDRESS_LOWER = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+VALID_ADDRESS_CHECKSUM = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+VALID_ADDRESS_UPPER = "0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48"
+
+
+class TestTokenAddress:
+    def test_accepts_lowercase_address(self):
+        token = TokenAddress(VALID_ADDRESS_LOWER)
+        assert token.value == VALID_ADDRESS_CHECKSUM
+
+    def test_accepts_checksummed_address(self):
+        token = TokenAddress(VALID_ADDRESS_CHECKSUM)
+        assert token.value == VALID_ADDRESS_CHECKSUM
+
+    def test_accepts_uppercase_address_and_normalizes(self):
+        token = TokenAddress(VALID_ADDRESS_UPPER)
+        assert token.value == VALID_ADDRESS_CHECKSUM
+
+    def test_str_returns_checksummed_value(self):
+        token = TokenAddress(VALID_ADDRESS_LOWER)
+        assert str(token) == VALID_ADDRESS_CHECKSUM
+
+    def test_equality_regardless_of_input_case(self):
+        a = TokenAddress(VALID_ADDRESS_LOWER)
+        b = TokenAddress(VALID_ADDRESS_CHECKSUM)
+        assert a == b
+
+    def test_hash_consistent_across_instances(self):
+        a = TokenAddress(VALID_ADDRESS_LOWER)
+        b = TokenAddress(VALID_ADDRESS_CHECKSUM)
+        assert hash(a) == hash(b)
+
+    def test_frozen_raises_on_mutation(self):
+        token = TokenAddress(VALID_ADDRESS_LOWER)
+        with pytest.raises(FrozenInstanceError):
+            token.value = "0x" + "0" * 40  # type: ignore[misc]
+
+    def test_rejects_too_short_address(self):
+        with pytest.raises(ValueError):
+            TokenAddress("0x1234")
+
+    def test_rejects_address_without_0x_prefix(self):
+        with pytest.raises(ValueError):
+            TokenAddress("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError):
+            TokenAddress("")
+
+    def test_rejects_random_string(self):
+        with pytest.raises(ValueError):
+            TokenAddress("not-an-address")
+
+    def test_rejects_address_wrong_length_too_long(self):
+        with pytest.raises(ValueError):
+            TokenAddress("0x" + "a" * 41)
+
+    def test_rejects_non_hex_characters(self):
+        with pytest.raises(ValueError):
+            TokenAddress("0x" + "z" * 40)
+
+
+# ---------------------------------------------------------------------------
+# ChainId
+# ---------------------------------------------------------------------------
+
+class TestChainId:
+    @pytest.mark.parametrize("chain_id", sorted(SUPPORTED_CHAIN_IDS))
+    def test_accepts_all_supported_chains(self, chain_id: int):
+        c = ChainId(chain_id)
+        assert c.value == chain_id
+
+    def test_ethereum_mainnet(self):
+        c = ChainId(1)
+        assert c.value == 1
+
+    def test_polygon(self):
+        c = ChainId(137)
+        assert c.value == 137
+
+    def test_arbitrum_one(self):
+        c = ChainId(42161)
+        assert c.value == 42161
+
+    def test_base(self):
+        c = ChainId(8453)
+        assert c.value == 8453
+
+    def test_int_conversion(self):
+        assert int(ChainId(1)) == 1
+
+    def test_str_conversion(self):
+        assert str(ChainId(137)) == "137"
+
+    def test_frozen_raises_on_mutation(self):
+        c = ChainId(1)
+        with pytest.raises(FrozenInstanceError):
+            c.value = 137  # type: ignore[misc]
+
+    def test_rejects_bsc(self):
+        with pytest.raises(ValueError, match="Unsupported chain_id"):
+            ChainId(56)
+
+    def test_rejects_avalanche(self):
+        with pytest.raises(ValueError, match="Unsupported chain_id"):
+            ChainId(43114)
+
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError, match="Unsupported chain_id"):
+            ChainId(0)
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError, match="Unsupported chain_id"):
+            ChainId(-1)
+
+    def test_error_message_lists_supported_chains(self):
+        with pytest.raises(ValueError, match="1") as exc_info:
+            ChainId(999)
+        assert "Supported chains" in str(exc_info.value)
+
+    def test_equality(self):
+        assert ChainId(1) == ChainId(1)
+        assert ChainId(1) != ChainId(137)
+
+    def test_hash(self):
+        assert hash(ChainId(1)) == hash(ChainId(1))
+
+
+# ---------------------------------------------------------------------------
+# FiatPrice
+# ---------------------------------------------------------------------------
+
+class TestFiatPrice:
+    def test_valid_usd(self):
+        p = FiatPrice(amount=Decimal("3000.00"), currency="USD")
+        assert p.amount == Decimal("3000.00")
+        assert p.currency == "USD"
+
+    def test_valid_eur(self):
+        p = FiatPrice(amount=Decimal("1.50"), currency="EUR")
+        assert p.currency == "EUR"
+
+    def test_valid_brl(self):
+        p = FiatPrice(amount=Decimal("0.01"), currency="BRL")
+        assert p.currency == "BRL"
+
+    def test_currency_normalized_to_uppercase(self):
+        p = FiatPrice(amount=Decimal("100"), currency="usd")
+        assert p.currency == "USD"
+
+    def test_currency_normalized_strips_whitespace(self):
+        p = FiatPrice(amount=Decimal("100"), currency=" EUR ")
+        assert p.currency == "EUR"
+
+    def test_zero_amount_is_valid(self):
+        p = FiatPrice(amount=Decimal("0"), currency="USD")
+        assert p.amount == Decimal("0")
+
+    def test_str_representation(self):
+        p = FiatPrice(amount=Decimal("3000"), currency="USD")
+        assert str(p) == "3000 USD"
+
+    def test_frozen_raises_on_mutation(self):
+        p = FiatPrice(amount=Decimal("100"), currency="USD")
+        with pytest.raises(FrozenInstanceError):
+            p.amount = Decimal("200")  # type: ignore[misc]
+
+    def test_rejects_negative_amount(self):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            FiatPrice(amount=Decimal("-0.01"), currency="USD")
+
+    def test_rejects_currency_too_short(self):
+        with pytest.raises(ValueError, match="ISO 4217"):
+            FiatPrice(amount=Decimal("1"), currency="US")
+
+    def test_rejects_currency_too_long(self):
+        with pytest.raises(ValueError, match="ISO 4217"):
+            FiatPrice(amount=Decimal("1"), currency="USDT")
+
+    def test_rejects_currency_with_digits(self):
+        with pytest.raises(ValueError, match="ISO 4217"):
+            FiatPrice(amount=Decimal("1"), currency="U5D")
+
+    def test_rejects_empty_currency(self):
+        with pytest.raises(ValueError, match="ISO 4217"):
+            FiatPrice(amount=Decimal("1"), currency="")
+
+    def test_equality(self):
+        a = FiatPrice(amount=Decimal("100"), currency="USD")
+        b = FiatPrice(amount=Decimal("100"), currency="usd")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# CryptoAmount
+# ---------------------------------------------------------------------------
+
+class TestCryptoAmount:
+    def test_valid_with_18_decimals(self):
+        one_eth = 10 ** 18
+        ca = CryptoAmount(raw=one_eth, decimals=18)
+        assert ca.as_decimal == Decimal("1")
+
+    def test_valid_with_6_decimals(self):
+        one_usdc = 1_000_000
+        ca = CryptoAmount(raw=one_usdc, decimals=6)
+        assert ca.as_decimal == Decimal("1")
+
+    def test_valid_zero(self):
+        ca = CryptoAmount(raw=0, decimals=18)
+        assert ca.as_decimal == Decimal("0")
+
+    def test_valid_zero_decimals(self):
+        ca = CryptoAmount(raw=5, decimals=0)
+        assert ca.as_decimal == Decimal("5")
+
+    def test_repr(self):
+        ca = CryptoAmount(raw=10 ** 18, decimals=18)
+        assert "1" in repr(ca)
+
+    def test_frozen_raises_on_mutation(self):
+        ca = CryptoAmount(raw=100, decimals=6)
+        with pytest.raises(FrozenInstanceError):
+            ca.raw = 200  # type: ignore[misc]
+
+    def test_rejects_negative_raw(self):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            CryptoAmount(raw=-1, decimals=18)
+
+    def test_rejects_decimals_above_18(self):
+        with pytest.raises(ValueError, match="must be in \\[0, 18\\]"):
+            CryptoAmount(raw=1, decimals=19)
+
+    def test_rejects_negative_decimals(self):
+        with pytest.raises(ValueError, match="must be in \\[0, 18\\]"):
+            CryptoAmount(raw=1, decimals=-1)
+
+    def test_equality(self):
+        a = CryptoAmount(raw=1000, decimals=6)
+        b = CryptoAmount(raw=1000, decimals=6)
+        assert a == b
+
+    def test_inequality_different_raw(self):
+        assert CryptoAmount(raw=1, decimals=6) != CryptoAmount(raw=2, decimals=6)
+
+    def test_inequality_different_decimals(self):
+        assert CryptoAmount(raw=1, decimals=6) != CryptoAmount(raw=1, decimals=18)
+
+
+# ---------------------------------------------------------------------------
+# TxHash
+# ---------------------------------------------------------------------------
+
+VALID_TX_HASH = "0x" + "ab12" * 16
+
+class TestTxHash:
+    def test_accepts_valid_hash_lowercase(self):
+        tx = TxHash("0x" + "a" * 64)
+        assert tx.value == "0x" + "a" * 64
+
+    def test_accepts_valid_hash_uppercase_and_normalizes(self):
+        tx = TxHash("0x" + "A" * 64)
+        assert tx.value == "0x" + "a" * 64
+
+    def test_accepts_valid_mixed_case_hash(self):
+        mixed = "0x" + VALID_TX_HASH[2:].upper()
+        tx = TxHash(mixed)
+        assert tx.value == VALID_TX_HASH.lower()
+
+    def test_str_returns_lowercased_hash(self):
+        tx = TxHash("0x" + "DEAD" * 16)
+        assert str(tx) == "0x" + "dead" * 16
+
+    def test_equality_regardless_of_input_case(self):
+        a = TxHash("0x" + "a" * 64)
+        b = TxHash("0x" + "A" * 64)
+        assert a == b
+
+    def test_frozen_raises_on_mutation(self):
+        tx = TxHash("0x" + "a" * 64)
+        with pytest.raises(FrozenInstanceError):
+            tx.value = "0x" + "b" * 64  # type: ignore[misc]
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash("")
+
+    def test_rejects_without_0x_prefix(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash("a" * 64)
+
+    def test_rejects_too_short(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash("0x" + "a" * 63)
+
+    def test_rejects_too_long(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash("0x" + "a" * 65)
+
+    def test_rejects_non_hex_characters(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash("0x" + "z" * 64)
+
+    def test_rejects_plain_address(self):
+        with pytest.raises(ValueError, match="Invalid transaction hash"):
+            TxHash(VALID_ADDRESS_CHECKSUM)
+
+    def test_hash_consistent(self):
+        a = TxHash("0x" + "a" * 64)
+        b = TxHash("0x" + "A" * 64)
+        assert hash(a) == hash(b)


### PR DESCRIPTION
## Summary

- Adds `TokenAddress` (`@dataclass(frozen=True)`) com validação EIP-55 checksum via `web3`
- Adds `ChainId` validado contra chains suportadas: 1 (Ethereum), 137 (Polygon), 42161 (Arbitrum One), 8453 (Base)
- Adds `FiatPrice` com validação de valor >= 0 e código ISO 4217 (3 letras)
- Adds `CryptoAmount` com `raw` (inteiro, unidade mínima) e `decimals` em [0, 18]
- Adds `TxHash` com validação `0x` + 64 caracteres hex, normalizado para lowercase
- Exportações integradas em `value_objects/__init__.py` sem quebrar `Address`, `Price`, `Slippage` ou `TokenAmount` existentes

## Test plan

- [x] 70 testes unitários em `tests/defi/domain/test_value_objects.py`
- [x] `FrozenInstanceError` verificado em todos os 5 value objects
- [x] `TokenAddress` rejeita endereços inválidos (sem `0x`, tamanho errado, hex inválido)
- [x] `ChainId` rejeita chains não suportadas (BSC, Avalanche, 0, negativos)
- [x] Casos inválidos cobertos para `FiatPrice`, `CryptoAmount` e `TxHash`
- [x] 82 testes no total passando (value objects + entities)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce immutable DeFi-specific value objects and document the DeFi bounded context foundation within the monorepo.

New Features:
- Add ChainId, TokenAddress, FiatPrice, CryptoAmount, and TxHash immutable value objects to the DeFi domain layer with strict validation for chains, addresses, fiat currencies, crypto amounts, and transaction hashes.

Enhancements:
- Document the DeFi bounded context architecture, domain entities, interfaces, and exceptions in the README, including value object usage examples and supported chains for ChainId.
- Export new DeFi value objects from the value_objects package without altering existing Address, Price, Slippage, or TokenAmount APIs.

Tests:
- Add a comprehensive test suite for the new DeFi value objects covering valid cases, edge cases, immutability, normalization behavior, and error messaging.