### PR TITLE
feat(#53): CoinGecko adapter — IMarketDataProvider implementation

### DIFF
--- a/app/services/defi/domain/exceptions.py
+++ b/app/services/defi/domain/exceptions.py
@@ -59,3 +59,18 @@ class PositionNotFoundError(DeFiError):
     def __init__(self, position_id: str) -> None:
         super().__init__(f"Position not found: id={position_id}")
         self.position_id = position_id
+
+
+class RateLimitError(DeFiError):
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"Rate limit exceeded for provider: {provider}")
+        self.provider = provider
+
+
+class ProviderUnavailableError(DeFiError):
+    def __init__(self, provider: str, status_code: int) -> None:
+        super().__init__(
+            f"Market data provider unavailable: {provider} (HTTP {status_code})"
+        )
+        self.provider = provider
+        self.status_code = status_code

--- a/app/services/defi/domain/interfaces/__init__.py
+++ b/app/services/defi/domain/interfaces/__init__.py
@@ -1,3 +1,4 @@
+from .market_data_provider import IMarketDataProvider
 from .pool_repository import IPoolRepository
 from .position_repository import IPositionRepository
 from .price_oracle import IPriceOracle
@@ -5,6 +6,7 @@ from .swap_service import ISwapService
 from .token_repository import ITokenRepository
 
 __all__ = [
+    "IMarketDataProvider",
     "IPoolRepository",
     "IPositionRepository",
     "IPriceOracle",

--- a/app/services/defi/domain/interfaces/market_data_provider.py
+++ b/app/services/defi/domain/interfaces/market_data_provider.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+from ..value_objects.market_quote import MarketQuote
+from ..value_objects.ohlcv_candle import OHLCVCandle
+
+
+class IMarketDataProvider(ABC):
+
+    @abstractmethod
+    async def get_quote(self, symbol: str, vs_currency: str = "usd") -> MarketQuote: ...
+
+    @abstractmethod
+    async def get_quotes(
+        self, symbols: list[str], vs_currency: str = "usd"
+    ) -> list[MarketQuote]: ...
+
+    @abstractmethod
+    async def get_ohlcv(
+        self, symbol: str, vs_currency: str = "usd", days: int = 1
+    ) -> list[OHLCVCandle]: ...

--- a/app/services/defi/domain/value_objects/__init__.py
+++ b/app/services/defi/domain/value_objects/__init__.py
@@ -1,6 +1,8 @@
 from .address import Address
+from .market_quote import MarketQuote
+from .ohlcv_candle import OHLCVCandle
 from .price import Price
 from .slippage import Slippage
 from .token_amount import TokenAmount
 
-__all__ = ["Address", "Price", "Slippage", "TokenAmount"]
+__all__ = ["Address", "MarketQuote", "OHLCVCandle", "Price", "Slippage", "TokenAmount"]

--- a/app/services/defi/domain/value_objects/market_quote.py
+++ b/app/services/defi/domain/value_objects/market_quote.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MarketQuote:
+    symbol: str
+    vs_currency: str
+    price: Decimal
+    price_change_24h: Optional[Decimal]
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        if self.price < 0:
+            raise ValueError("MarketQuote.price must be >= 0")

--- a/app/services/defi/domain/value_objects/ohlcv_candle.py
+++ b/app/services/defi/domain/value_objects/ohlcv_candle.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class OHLCVCandle:
+    timestamp: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal

--- a/app/services/defi/infrastructure/market_data/__init__.py
+++ b/app/services/defi/infrastructure/market_data/__init__.py
@@ -1,2 +1,3 @@
-# Market data feed adapters (CoinGecko, etc.) — populated in subsequent features.
-__all__: list[str] = []
+from .coingecko_adapter import CoinGeckoAdapter, SYMBOL_TO_COIN_ID
+
+__all__ = ["CoinGeckoAdapter", "SYMBOL_TO_COIN_ID"]

--- a/app/services/defi/infrastructure/market_data/coingecko_adapter.py
+++ b/app/services/defi/infrastructure/market_data/coingecko_adapter.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import httpx
+
+from ...domain.exceptions import ProviderUnavailableError, RateLimitError
+from ...domain.interfaces.market_data_provider import IMarketDataProvider
+from ...domain.value_objects.market_quote import MarketQuote
+from ...domain.value_objects.ohlcv_candle import OHLCVCandle
+
+_PROVIDER_NAME = "CoinGecko"
+_BASE_URL = "https://api.coingecko.com/api/v3"
+
+# Maps well-known ticker symbols to CoinGecko coin IDs.
+SYMBOL_TO_COIN_ID: dict[str, str] = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+    "SOL": "solana",
+}
+
+
+def _resolve_coin_id(symbol: str) -> str:
+    upper = symbol.upper()
+    return SYMBOL_TO_COIN_ID.get(upper, upper.lower())
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if response.status_code == 429:
+        raise RateLimitError(_PROVIDER_NAME)
+    if response.status_code >= 500:
+        raise ProviderUnavailableError(_PROVIDER_NAME, response.status_code)
+    response.raise_for_status()
+
+
+class CoinGeckoAdapter(IMarketDataProvider):
+
+    def __init__(self, client: httpx.AsyncClient, base_url: str = _BASE_URL) -> None:
+        self._client = client
+        self._base_url = base_url.rstrip("/")
+
+    async def get_quote(self, symbol: str, vs_currency: str = "usd") -> MarketQuote:
+        coin_id = _resolve_coin_id(symbol)
+        response = await self._client.get(
+            f"{self._base_url}/simple/price",
+            params={
+                "ids": coin_id,
+                "vs_currencies": vs_currency,
+                "include_24hr_change": "true",
+            },
+        )
+        _raise_for_status(response)
+        data = response.json()
+        coin_data = data[coin_id]
+        return MarketQuote(
+            symbol=symbol.upper(),
+            vs_currency=vs_currency.lower(),
+            price=Decimal(str(coin_data[vs_currency.lower()])),
+            price_change_24h=(
+                Decimal(str(coin_data[f"{vs_currency.lower()}_24h_change"]))
+                if f"{vs_currency.lower()}_24h_change" in coin_data
+                else None
+            ),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+
+    async def get_quotes(
+        self, symbols: list[str], vs_currency: str = "usd"
+    ) -> list[MarketQuote]:
+        coin_ids = [_resolve_coin_id(s) for s in symbols]
+        symbol_map = {_resolve_coin_id(s): s.upper() for s in symbols}
+
+        response = await self._client.get(
+            f"{self._base_url}/simple/price",
+            params={
+                "ids": ",".join(coin_ids),
+                "vs_currencies": vs_currency,
+                "include_24hr_change": "true",
+            },
+        )
+        _raise_for_status(response)
+        data = response.json()
+        now = datetime.now(tz=timezone.utc)
+        quotes: list[MarketQuote] = []
+        for coin_id in coin_ids:
+            if coin_id not in data:
+                continue
+            coin_data = data[coin_id]
+            vs = vs_currency.lower()
+            quotes.append(
+                MarketQuote(
+                    symbol=symbol_map[coin_id],
+                    vs_currency=vs,
+                    price=Decimal(str(coin_data[vs])),
+                    price_change_24h=(
+                        Decimal(str(coin_data[f"{vs}_24h_change"]))
+                        if f"{vs}_24h_change" in coin_data
+                        else None
+                    ),
+                    timestamp=now,
+                )
+            )
+        return quotes
+
+    async def get_ohlcv(
+        self, symbol: str, vs_currency: str = "usd", days: int = 1
+    ) -> list[OHLCVCandle]:
+        coin_id = _resolve_coin_id(symbol)
+        response = await self._client.get(
+            f"{self._base_url}/coins/{coin_id}/ohlc",
+            params={"vs_currency": vs_currency, "days": days},
+        )
+        _raise_for_status(response)
+        # Each entry: [timestamp_ms, open, high, low, close]
+        raw: list[list[float]] = response.json()
+        return [
+            OHLCVCandle(
+                timestamp=datetime.fromtimestamp(entry[0] / 1000, tz=timezone.utc),
+                open=Decimal(str(entry[1])),
+                high=Decimal(str(entry[2])),
+                low=Decimal(str(entry[3])),
+                close=Decimal(str(entry[4])),
+            )
+            for entry in raw
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ asyncpg>=0.29.0
 pytest>=8.2.0
 pytest-asyncio>=0.23.0
 httpx>=0.27.0
+respx>=0.21.0

--- a/tests/defi/test_coingecko_adapter.py
+++ b/tests/defi/test_coingecko_adapter.py
@@ -1,0 +1,197 @@
+import json
+from decimal import Decimal
+
+import httpx
+import pytest
+import respx
+
+from app.services.defi.domain.exceptions import ProviderUnavailableError, RateLimitError
+from app.services.defi.infrastructure.market_data.coingecko_adapter import (
+    CoinGeckoAdapter,
+    SYMBOL_TO_COIN_ID,
+)
+
+BASE_URL = "https://api.coingecko.com/api/v3"
+
+SIMPLE_PRICE_RESPONSE = {
+    "bitcoin": {"usd": 65000.0, "usd_24h_change": 1.5},
+    "ethereum": {"usd": 3500.0, "usd_24h_change": -0.8},
+    "solana": {"usd": 150.0, "usd_24h_change": 2.1},
+}
+
+OHLCV_RESPONSE = [
+    [1717200000000, 64000.0, 66000.0, 63500.0, 65000.0],
+    [1717203600000, 65000.0, 65500.0, 64800.0, 65200.0],
+]
+
+
+@pytest.fixture
+def http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient()
+
+
+@pytest.mark.asyncio
+async def test_symbol_mappings_btc_eth_sol() -> None:
+    assert SYMBOL_TO_COIN_ID["BTC"] == "bitcoin"
+    assert SYMBOL_TO_COIN_ID["ETH"] == "ethereum"
+    assert SYMBOL_TO_COIN_ID["SOL"] == "solana"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quote_btc(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(
+            200, json={"bitcoin": {"usd": 65000.0, "usd_24h_change": 1.5}}
+        )
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quote = await adapter.get_quote("BTC")
+
+    assert quote.symbol == "BTC"
+    assert quote.vs_currency == "usd"
+    assert quote.price == Decimal("65000.0")
+    assert quote.price_change_24h == Decimal("1.5")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quote_eth(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(
+            200, json={"ethereum": {"usd": 3500.0, "usd_24h_change": -0.8}}
+        )
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quote = await adapter.get_quote("ETH")
+
+    assert quote.symbol == "ETH"
+    assert quote.price == Decimal("3500.0")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quote_sol(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(
+            200, json={"solana": {"usd": 150.0, "usd_24h_change": 2.1}}
+        )
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quote = await adapter.get_quote("SOL")
+
+    assert quote.symbol == "SOL"
+    assert quote.price == Decimal("150.0")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quotes_multiple(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(200, json=SIMPLE_PRICE_RESPONSE)
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quotes = await adapter.get_quotes(["BTC", "ETH", "SOL"])
+
+    assert len(quotes) == 3
+    symbols = {q.symbol for q in quotes}
+    assert symbols == {"BTC", "ETH", "SOL"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_ohlcv(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/coins/bitcoin/ohlc").mock(
+        return_value=httpx.Response(200, json=OHLCV_RESPONSE)
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    candles = await adapter.get_ohlcv("BTC", days=1)
+
+    assert len(candles) == 2
+    first = candles[0]
+    assert first.open == Decimal("64000.0")
+    assert first.high == Decimal("66000.0")
+    assert first.low == Decimal("63500.0")
+    assert first.close == Decimal("65000.0")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rate_limit_error_on_429(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(429, text="Too Many Requests")
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+
+    with pytest.raises(RateLimitError) as exc_info:
+        await adapter.get_quote("BTC")
+
+    assert exc_info.value.provider == "CoinGecko"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_provider_unavailable_on_500(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(500, text="Internal Server Error")
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        await adapter.get_quote("BTC")
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.provider == "CoinGecko"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_provider_unavailable_on_503(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(503, text="Service Unavailable")
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        await adapter.get_quote("ETH")
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rate_limit_on_get_ohlcv_429(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/coins/bitcoin/ohlc").mock(
+        return_value=httpx.Response(429, text="Too Many Requests")
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+
+    with pytest.raises(RateLimitError):
+        await adapter.get_ohlcv("BTC")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quote_no_24h_change(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(200, json={"bitcoin": {"usd": 65000.0}})
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quote = await adapter.get_quote("BTC")
+
+    assert quote.price_change_24h is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_quotes_skips_missing_coin(http_client: httpx.AsyncClient) -> None:
+    respx.get(f"{BASE_URL}/simple/price").mock(
+        return_value=httpx.Response(
+            200, json={"bitcoin": {"usd": 65000.0, "usd_24h_change": 1.0}}
+        )
+    )
+    adapter = CoinGeckoAdapter(http_client, base_url=BASE_URL)
+    quotes = await adapter.get_quotes(["BTC", "UNKNOWN"])
+
+    assert len(quotes) == 1
+    assert quotes[0].symbol == "BTC"


### PR DESCRIPTION
## Summary

- Implements `IMarketDataProvider` interface with `get_quote`, `get_quotes`, and `get_ohlcv` methods
- Adds `CoinGeckoAdapter` at `app/services/defi/infrastructure/market_data/coingecko_adapter.py` using constructor-injected `httpx.AsyncClient`
- Raises `RateLimitError` on HTTP 429 and `ProviderUnavailableError` on HTTP 5xx responses
- BTC/ETH/SOL symbol mappings to CoinGecko coin IDs (`bitcoin`, `ethereum`, `solana`)
- Adds `MarketQuote` and `OHLCVCandle` value objects to the domain layer
- Adds `respx>=0.21.0` to requirements for HTTP mocking in tests

## Test plan

- [x] 12 unit tests using `respx` mocking — all pass (`pytest tests/defi/test_coingecko_adapter.py`)
- [x] `RateLimitError` raised on HTTP 429 (`get_quote`, `get_ohlcv`)
- [x] `ProviderUnavailableError` raised on HTTP 500 and 503
- [x] BTC/ETH/SOL symbol mappings verified
- [x] `get_quotes` correctly skips missing coins from the response
- [x] Optional `price_change_24h` handled when absent from API response

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a CoinGecko-backed market data provider with domain value objects for quotes and OHLCV candles and associated error handling.

New Features:
- Add IMarketDataProvider interface for fetching single and multiple quotes and OHLCV data.
- Implement CoinGeckoAdapter as an IMarketDataProvider using HTTPX with symbol-to-coin ID mappings for BTC, ETH, and SOL.
- Introduce MarketQuote and OHLCVCandle value objects to represent market data in the domain layer.

Enhancements:
- Expose CoinGeckoAdapter and market data value objects through the respective package __init__ modules.
- Add domain-level RateLimitError and ProviderUnavailableError exceptions for upstream provider failures.

Build:
- Add respx as a dependency for HTTP client mocking in tests.

Tests:
- Add unit test coverage for CoinGeckoAdapter success paths, symbol mappings, optional 24h change handling, and behavior when coins are missing from responses.
- Add tests verifying correct raising of RateLimitError on HTTP 429 and ProviderUnavailableError on HTTP 5xx responses.