### PR TITLE
feat(#59): Building API enpoint GET /defi/quotes/{symbol}

### DIFF
--- a/app/services/defi/api/routers/quotes_router.py
+++ b/app/services/defi/api/routers/quotes_router.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
-from ..dependencies import get_quote_service
-from ..schemas.quote import QuoteRequest, QuoteResponse
-from ...application.quote_service import SwapQuoteService
+from ..dependencies import get_market_quote_service, get_quote_service
+from ..schemas.quote import MarketQuoteResponse, QuoteRequest, QuoteResponse
+from ...application.quote_service import QuoteService, SwapQuoteService
 from ...domain.value_objects.slippage import Slippage
 
 quotes_router = APIRouter(prefix="/quotes", tags=["DeFi – Quotes"])
@@ -25,3 +25,30 @@ async def get_quote(
         slippage=Slippage(bps=body.slippage_bps),
     )
     return QuoteResponse(**result)
+
+
+@quotes_router.get(
+    "/{symbol}",
+    response_model=MarketQuoteResponse,
+    summary="Get a spot market quote for a cryptocurrency symbol",
+)
+async def get_market_quote(
+    symbol: str,
+    market_quote_service: QuoteService = Depends(get_market_quote_service),
+) -> MarketQuoteResponse:
+    quote = await market_quote_service.get_quote(symbol)
+
+    if quote.price_usd == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Symbol not found: {symbol.upper()}",
+        )
+
+    return MarketQuoteResponse(
+        symbol=quote.symbol,
+        price_usd=str(quote.price_usd),
+        change_24h_pct=float(quote.change_24h) if quote.change_24h is not None else 0.0,
+        volume_24h_usd=str(quote.volume_24h),
+        market_cap_usd=str(quote.market_cap),
+        fetched_at=quote.fetched_at,
+    )

--- a/app/services/defi/api/schemas/__init__.py
+++ b/app/services/defi/api/schemas/__init__.py
@@ -1,6 +1,6 @@
 from .common import ErrorResponse, HealthResponse, HealthStatus, PaginatedResponse
 from .pool import PoolResponse
-from .quote import QuoteRequest, QuoteResponse
+from .quote import MarketQuoteResponse, QuoteRequest, QuoteResponse
 from .token import TokenResponse
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "HealthStatus",
     "PaginatedResponse",
     "PoolResponse",
+    "MarketQuoteResponse",
     "QuoteRequest",
     "QuoteResponse",
     "TokenResponse",

--- a/app/services/defi/api/schemas/quote.py
+++ b/app/services/defi/api/schemas/quote.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
@@ -17,3 +19,12 @@ class QuoteResponse(BaseModel):
     price_impact_bps: int
     slippage_bps: int
     pool_count: int
+
+
+class MarketQuoteResponse(BaseModel):
+    symbol: str
+    price_usd: str
+    change_24h_pct: float
+    volume_24h_usd: str
+    market_cap_usd: str
+    fetched_at: datetime

--- a/tests/defi/api/test_quotes_router.py
+++ b/tests/defi/api/test_quotes_router.py
@@ -1,0 +1,151 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.services.defi.api.dependencies import get_market_quote_service
+from app.services.defi.api.routers.quotes_router import quotes_router
+from app.services.defi.application.quote_service import QuoteService
+from app.services.defi.domain.entities.asset_quote import AssetQuote
+
+
+def _make_client(mock_service: QuoteService) -> TestClient:
+    app = FastAPI()
+    app.dependency_overrides[get_market_quote_service] = lambda: mock_service
+    app.include_router(quotes_router)
+    return TestClient(app)
+
+
+def _mock_asset_quote(
+    symbol: str,
+    price_usd: Decimal = Decimal("50000.00"),
+    change_24h: Decimal | None = Decimal("2.5"),
+    volume_24h: Decimal = Decimal("1000000000"),
+    market_cap: Decimal = Decimal("900000000000"),
+) -> AssetQuote:
+    return AssetQuote(
+        symbol=symbol,
+        price_usd=price_usd,
+        change_24h=change_24h,
+        volume_24h=volume_24h,
+        market_cap=market_cap,
+        fetched_at=datetime(2026, 1, 15, 12, 30, 0, tzinfo=timezone.utc),
+    )
+
+
+class TestGetMarketQuoteEndpoint:
+
+    @pytest.mark.parametrize("symbol", ["BTC", "ETH"])
+    def test_returns_200_for_known_symbols(self, symbol: str):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote(symbol)
+        client = _make_client(service)
+
+        response = client.get(f"/quotes/{symbol}")
+
+        assert response.status_code == 200
+
+    def test_response_has_required_fields(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert data["symbol"] == "BTC"
+        assert "price_usd" in data
+        assert "change_24h_pct" in data
+        assert "volume_24h_usd" in data
+        assert "market_cap_usd" in data
+        assert "fetched_at" in data
+
+    def test_price_usd_is_string(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert isinstance(data["price_usd"], str)
+        assert data["price_usd"] == "50000.00"
+
+    def test_volume_24h_usd_is_string(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert isinstance(data["volume_24h_usd"], str)
+
+    def test_market_cap_usd_is_string(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert isinstance(data["market_cap_usd"], str)
+
+    def test_change_24h_pct_is_float(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert isinstance(data["change_24h_pct"], float)
+
+    def test_change_24h_pct_zero_when_none(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC", change_24h=None)
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        assert data["change_24h_pct"] == 0.0
+
+    def test_fetched_at_is_iso_8601(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote("BTC")
+        client = _make_client(service)
+
+        data = client.get("/quotes/BTC").json()
+
+        fetched_at = datetime.fromisoformat(data["fetched_at"])
+        assert fetched_at.year == 2026
+        assert fetched_at.month == 1
+
+    def test_ethereum_quote(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote(
+            "ETH",
+            price_usd=Decimal("3500.50"),
+            change_24h=Decimal("-1.2"),
+            volume_24h=Decimal("500000000"),
+            market_cap=Decimal("420000000000"),
+        )
+        client = _make_client(service)
+
+        data = client.get("/quotes/ETH").json()
+
+        assert data["symbol"] == "ETH"
+        assert data["price_usd"] == "3500.50"
+        assert data["change_24h_pct"] == -1.2
+        assert data["volume_24h_usd"] == "500000000"
+        assert data["market_cap_usd"] == "420000000000"
+
+    def test_returns_404_for_unknown_symbol(self):
+        service = AsyncMock(spec=QuoteService)
+        service.get_quote.return_value = _mock_asset_quote(
+            "UNKNOWN", price_usd=Decimal(0)
+        )
+        client = _make_client(service)
+
+        response = client.get("/quotes/UNKNOWN")
+
+        assert response.status_code == 404
+        assert "UNKNOWN" in response.json()["detail"]


### PR DESCRIPTION
feat(#59): Building API enpoint GET /defi/quotes/{symbol}

## Summary by Sourcery

Add a new spot market quote endpoint for cryptocurrency symbols and expose its response schema.

New Features:
- Introduce GET /quotes/{symbol} endpoint to retrieve spot market quotes for a given cryptocurrency symbol.
- Define MarketQuoteResponse schema and export it from the API schemas package for use by clients.

Enhancements:
- Return 404 Not Found when a requested symbol has no valid market price instead of returning an empty quote.

Tests:
- Add API tests covering successful responses, response shape and types, ISO-8601 timestamps, handling of missing 24h change, and 404 behavior for unknown symbols.