### PR TITLE
feat(#88): Building ResearchReport entity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,26 @@
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List
+
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List, Dict, Any
 
 from app.contract_generator import ERC20ContractGenerator
+from app.services.defi.api.dependencies import get_research_report_service
+from app.services.defi.api.routers import research_router
+from app.services.defi.application.research_report_service import ResearchReportService
+from app.services.defi.infrastructure.persistence import InMemoryResearchReportRepository
 from app.token_services import format_token_transfer_data, prepare_contract_interaction_data
 
-app = FastAPI(title="FastChainBank")
+
+@asynccontextmanager
+async def lifespan(application: FastAPI):
+    report_repo = InMemoryResearchReportRepository()
+    application.state.defi_research_service = ResearchReportService(repository=report_repo)
+    yield
+
+
+app = FastAPI(title="FastChainBank", lifespan=lifespan)
+app.include_router(research_router)
 
 
 class ERC20Properties(BaseModel):

--- a/app/services/defi/api/dependencies.py
+++ b/app/services/defi/api/dependencies.py
@@ -1,7 +1,12 @@
 from fastapi import Request
 
 from ..application.quote_service import QuoteService
+from ..application.research_report_service import ResearchReportService
 
 
 def get_quote_service(request: Request) -> QuoteService:
     return request.app.state.defi_quote_service
+
+
+def get_research_report_service(request: Request) -> ResearchReportService:
+    return request.app.state.defi_research_service

--- a/app/services/defi/api/routers/__init__.py
+++ b/app/services/defi/api/routers/__init__.py
@@ -1,3 +1,4 @@
 from .defi_router import router
+from .research_router import router as research_router
 
-__all__ = ["router"]
+__all__ = ["router", "research_router"]

--- a/app/services/defi/api/routers/research_router.py
+++ b/app/services/defi/api/routers/research_router.py
@@ -1,0 +1,85 @@
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ...application.research_report_service import ResearchReportService
+from ...domain.entities.research_report import ResearchReport
+from ...domain.exceptions import ResearchReportNotFoundError
+from ..dependencies import get_research_report_service
+from ..schemas.research import (
+    ResearchListResponse,
+    ResearchPublishRequest,
+    ResearchReportResponse,
+    ResearchSearchResponse,
+)
+
+router = APIRouter(prefix="/v1/defi/research", tags=["defi/research"])
+
+
+def _to_response(report: ResearchReport) -> ResearchReportResponse:
+    return ResearchReportResponse(
+        slug=report.slug,
+        title=report.title,
+        body_markdown=report.body_markdown,
+        summary=report.summary,
+        published_at=report.published_at,
+        categories=report.categories,
+        tags=report.tags,
+        version=report.version,
+        author_type=report.author_type,
+    )
+
+
+@router.post("", response_model=ResearchReportResponse, status_code=status.HTTP_201_CREATED)
+async def publish_report(
+    body: ResearchPublishRequest,
+    service: ResearchReportService = Depends(get_research_report_service),
+) -> ResearchReportResponse:
+    report = await service.publish(body.model_dump())
+    return _to_response(report)
+
+
+@router.get("", response_model=ResearchListResponse)
+async def list_reports(
+    category: Optional[str] = Query(None),
+    tag: Optional[str] = Query(None),
+    service: ResearchReportService = Depends(get_research_report_service),
+) -> ResearchListResponse:
+    if category:
+        items = await service.list_by_category(category)
+    elif tag:
+        items = await service.list_by_tag(tag)
+    else:
+        items = await service.search("")
+    return ResearchListResponse(items=[_to_response(r) for r in items], total=len(items))
+
+
+@router.get("/search", response_model=ResearchSearchResponse)
+async def search_reports(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, ge=1, le=100),
+    service: ResearchReportService = Depends(get_research_report_service),
+) -> ResearchSearchResponse:
+    items = await service.search(q, limit=limit)
+    return ResearchSearchResponse(items=[_to_response(r) for r in items], total=len(items))
+
+
+@router.get("/{slug}", response_model=ResearchReportResponse)
+async def get_report(
+    slug: str,
+    service: ResearchReportService = Depends(get_research_report_service),
+) -> ResearchReportResponse:
+    try:
+        report = await service.get_by_slug(slug)
+    except ResearchReportNotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+    return _to_response(report)
+
+
+@router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_report(
+    slug: str,
+    service: ResearchReportService = Depends(get_research_report_service),
+) -> None:
+    await service.delete_by_slug(slug)

--- a/app/services/defi/api/schemas/__init__.py
+++ b/app/services/defi/api/schemas/__init__.py
@@ -1,5 +1,15 @@
 from .pool import PoolResponse
 from .quote import QuoteRequest, QuoteResponse
+from .research import ResearchListResponse, ResearchPublishRequest, ResearchReportResponse, ResearchSearchResponse
 from .token import TokenResponse
 
-__all__ = ["PoolResponse", "QuoteRequest", "QuoteResponse", "TokenResponse"]
+__all__ = [
+    "PoolResponse",
+    "QuoteRequest",
+    "QuoteResponse",
+    "ResearchListResponse",
+    "ResearchPublishRequest",
+    "ResearchReportResponse",
+    "ResearchSearchResponse",
+    "TokenResponse",
+]

--- a/app/services/defi/api/schemas/research.py
+++ b/app/services/defi/api/schemas/research.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ResearchPublishRequest(BaseModel):
+    report_id: UUID
+    slug: Optional[str] = Field(default=None, max_length=250, pattern=r"^[a-z0-9-]+$")
+    title: str = Field(max_length=200)
+    body_markdown: str
+    summary: str = Field(max_length=500)
+    published_at: datetime
+    categories: list[str] = Field(min_length=1)
+    tags: list[str] = Field(min_length=1)
+    version: int = Field(ge=1)
+    author_type: Literal["editorial", "automated"]
+
+
+class ResearchReportResponse(BaseModel):
+    slug: str
+    title: str
+    body_markdown: str
+    summary: str
+    published_at: datetime
+    categories: list[str]
+    tags: list[str]
+    version: int
+    author_type: str
+
+
+class ResearchListResponse(BaseModel):
+    items: list[ResearchReportResponse]
+    total: int
+
+
+class ResearchSearchResponse(BaseModel):
+    items: list[ResearchReportResponse]
+    total: int

--- a/app/services/defi/application/__init__.py
+++ b/app/services/defi/application/__init__.py
@@ -1,3 +1,4 @@
 from .quote_service import QuoteService
+from .research_report_service import ResearchReportService
 
-__all__ = ["QuoteService"]
+__all__ = ["QuoteService", "ResearchReportService"]

--- a/app/services/defi/application/research_report_service.py
+++ b/app/services/defi/application/research_report_service.py
@@ -1,0 +1,58 @@
+import uuid
+from typing import Any, Optional
+
+from ..domain.entities.research_report import ResearchReport
+from ..domain.exceptions import ResearchReportNotFoundError
+from ..domain.interfaces.research_report_repository import IResearchReportRepository
+
+FORBIDDEN_FIELDS = {"user_id", "wallet_address", "subscriber_id", "personalized_for"}
+
+
+class ResearchReportService:
+
+    def __init__(self, repository: IResearchReportRepository) -> None:
+        self._repository = repository
+
+    async def publish(self, payload: dict[str, Any]) -> ResearchReport:
+        for field in FORBIDDEN_FIELDS:
+            if field in payload:
+                raise ValueError(
+                    f"{field} is forbidden in research report payloads — "
+                    "reports are impersonal and must not be personalized"
+                )
+
+        if "author_type" in payload and payload["author_type"] == "user":
+            raise ValueError(
+                'author_type must be "editorial" or "automated", never "user"'
+            )
+
+        report = ResearchReport.model_validate(payload)
+        await self._repository.upsert(report)
+        return report
+
+    async def get_by_id(self, report_id: uuid.UUID) -> ResearchReport:
+        report = await self._repository.get_by_id(report_id)
+        if report is None:
+            raise ResearchReportNotFoundError(str(report_id))
+        return report
+
+    async def get_by_slug(self, slug: str) -> ResearchReport:
+        report = await self._repository.get_by_slug(slug)
+        if report is None:
+            raise ResearchReportNotFoundError(slug)
+        return report
+
+    async def list_by_category(self, category: str) -> list[ResearchReport]:
+        return await self._repository.list_by_category(category)
+
+    async def list_by_tag(self, tag: str) -> list[ResearchReport]:
+        return await self._repository.list_by_tag(tag)
+
+    async def search(self, query: str, limit: int = 20) -> list[ResearchReport]:
+        return await self._repository.search_fts(query, limit=limit)
+
+    async def delete(self, report_id: uuid.UUID) -> None:
+        await self._repository.delete(report_id)
+
+    async def delete_by_slug(self, slug: str) -> None:
+        await self._repository.delete_by_slug(slug)

--- a/app/services/defi/domain/entities/__init__.py
+++ b/app/services/defi/domain/entities/__init__.py
@@ -1,6 +1,7 @@
 from .pool import Pool
 from .position import Position
 from .protocol import Protocol, ProtocolName
+from .research_report import ResearchReport
 from .token import Token
 
-__all__ = ["Pool", "Position", "Protocol", "ProtocolName", "Token"]
+__all__ = ["Pool", "Position", "Protocol", "ProtocolName", "ResearchReport", "Token"]

--- a/app/services/defi/domain/entities/research_report.py
+++ b/app/services/defi/domain/entities/research_report.py
@@ -1,0 +1,84 @@
+import re
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+FORBIDDEN_FIELDS = {"user_id", "wallet_address", "subscriber_id", "personalized_for"}
+
+
+def _slugify(value: str) -> str:
+    value = value.lower().strip()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = value.strip("-")
+    return value
+
+
+class ResearchReport(BaseModel):
+
+    report_id: UUID
+    slug: str = Field(max_length=250, pattern=r"^[a-z0-9-]+$")
+    title: str = Field(max_length=200)
+    body_markdown: str
+    summary: str = Field(max_length=500)
+    published_at: datetime
+    categories: list[str]
+    tags: list[str]
+    version: int = Field(ge=1)
+    author_type: Literal["editorial", "automated"]
+
+    model_config = {"frozen": True}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _generate_slug_and_reject_forbidden(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            if "title" in data and (data.get("slug") is None or data.get("slug") == ""):
+                data["slug"] = _slugify(data["title"])
+            for field in FORBIDDEN_FIELDS:
+                if field in data:
+                    raise ValueError(
+                        f"{field} is forbidden in ResearchReport — "
+                        "reports are impersonal and must not be personalized"
+                    )
+            if "author_type" in data and data["author_type"] == "user":
+                raise ValueError(
+                    'author_type must be "editorial" or "automated", never "user"'
+                )
+        return data
+
+    @field_validator("title")
+    @classmethod
+    def title_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("title must not be blank")
+        return v
+
+    @field_validator("summary")
+    @classmethod
+    def summary_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("summary must not be blank")
+        return v
+
+    @field_validator("body_markdown")
+    @classmethod
+    def body_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("body_markdown must not be blank")
+        return v
+
+    @field_validator("categories")
+    @classmethod
+    def categories_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("categories must not be empty")
+        return v
+
+    @field_validator("tags")
+    @classmethod
+    def tags_not_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("tags must not be empty")
+        return v

--- a/app/services/defi/domain/exceptions.py
+++ b/app/services/defi/domain/exceptions.py
@@ -59,3 +59,9 @@ class PositionNotFoundError(DeFiError):
     def __init__(self, position_id: str) -> None:
         super().__init__(f"Position not found: id={position_id}")
         self.position_id = position_id
+
+
+class ResearchReportNotFoundError(DeFiError):
+    def __init__(self, report_id: str) -> None:
+        super().__init__(f"ResearchReport not found: id={report_id}")
+        self.report_id = report_id

--- a/app/services/defi/domain/interfaces/__init__.py
+++ b/app/services/defi/domain/interfaces/__init__.py
@@ -1,6 +1,7 @@
 from .pool_repository import IPoolRepository
 from .position_repository import IPositionRepository
 from .price_oracle import IPriceOracle
+from .research_report_repository import IResearchReportRepository
 from .swap_service import ISwapService
 from .token_repository import ITokenRepository
 
@@ -8,6 +9,7 @@ __all__ = [
     "IPoolRepository",
     "IPositionRepository",
     "IPriceOracle",
+    "IResearchReportRepository",
     "ISwapService",
     "ITokenRepository",
 ]

--- a/app/services/defi/domain/interfaces/research_report_repository.py
+++ b/app/services/defi/domain/interfaces/research_report_repository.py
@@ -1,0 +1,32 @@
+import uuid
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from ..entities.research_report import ResearchReport
+
+
+class IResearchReportRepository(ABC):
+
+    @abstractmethod
+    async def get_by_id(self, report_id: uuid.UUID) -> Optional[ResearchReport]: ...
+
+    @abstractmethod
+    async def get_by_slug(self, slug: str) -> Optional[ResearchReport]: ...
+
+    @abstractmethod
+    async def list_by_category(self, category: str) -> list[ResearchReport]: ...
+
+    @abstractmethod
+    async def list_by_tag(self, tag: str) -> list[ResearchReport]: ...
+
+    @abstractmethod
+    async def search_fts(self, query: str, limit: int = 20) -> list[ResearchReport]: ...
+
+    @abstractmethod
+    async def upsert(self, report: ResearchReport) -> None: ...
+
+    @abstractmethod
+    async def delete(self, report_id: uuid.UUID) -> None: ...
+
+    @abstractmethod
+    async def delete_by_slug(self, slug: str) -> None: ...

--- a/app/services/defi/infrastructure/persistence/__init__.py
+++ b/app/services/defi/infrastructure/persistence/__init__.py
@@ -1,2 +1,12 @@
-# Concrete repository implementations — populated in subsequent features.
-__all__: list[str] = []
+from .database import Database
+from .in_memory_research_report_repository import InMemoryResearchReportRepository
+from .models import Base, ResearchReportModel
+from .research_report_repository import PostgresResearchReportRepository
+
+__all__ = [
+    "Base",
+    "Database",
+    "InMemoryResearchReportRepository",
+    "PostgresResearchReportRepository",
+    "ResearchReportModel",
+]

--- a/app/services/defi/infrastructure/persistence/database.py
+++ b/app/services/defi/infrastructure/persistence/database.py
@@ -1,0 +1,28 @@
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+class Database:
+
+    def __init__(self, url: str) -> None:
+        self._engine = create_async_engine(url, pool_pre_ping=True, echo=False)
+        self._session_factory = async_sessionmaker(
+            bind=self._engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+
+    @asynccontextmanager
+    async def session(self) -> AsyncGenerator[AsyncSession, None]:
+        async with self._session_factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    async def close(self) -> None:
+        await self._engine.dispose()

--- a/app/services/defi/infrastructure/persistence/in_memory_research_report_repository.py
+++ b/app/services/defi/infrastructure/persistence/in_memory_research_report_repository.py
@@ -1,0 +1,57 @@
+import json
+from typing import Optional
+from uuid import UUID
+
+from ...domain.entities.research_report import ResearchReport
+from ...domain.interfaces.research_report_repository import IResearchReportRepository
+
+
+class InMemoryResearchReportRepository(IResearchReportRepository):
+
+    def __init__(self) -> None:
+        self._store: dict[UUID, ResearchReport] = {}
+
+    async def get_by_id(self, report_id: UUID) -> Optional[ResearchReport]:
+        return self._store.get(report_id)
+
+    async def get_by_slug(self, slug: str) -> Optional[ResearchReport]:
+        for report in self._store.values():
+            if report.slug == slug:
+                return report
+        return None
+
+    async def delete_by_slug(self, slug: str) -> None:
+        keys = [k for k, v in self._store.items() if v.slug == slug]
+        for k in keys:
+            self._store.pop(k, None)
+
+    async def list_by_category(self, category: str) -> list[ResearchReport]:
+        return [r for r in self._store.values() if category in r.categories]
+
+    async def list_by_tag(self, tag: str) -> list[ResearchReport]:
+        return [r for r in self._store.values() if tag in r.tags]
+
+    async def search_fts(self, query: str, limit: int = 20) -> list[ResearchReport]:
+        q_lower = query.lower()
+        results: list[tuple[float, ResearchReport]] = []
+        for report in self._store.values():
+            text_blob = " ".join(
+                [
+                    report.title,
+                    report.summary,
+                    report.body_markdown,
+                    *report.categories,
+                    *report.tags,
+                ]
+            ).lower()
+            if q_lower in text_blob:
+                score = text_blob.count(q_lower)
+                results.append((score, report))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return [r for _, r in results[:limit]]
+
+    async def upsert(self, report: ResearchReport) -> None:
+        self._store[report.report_id] = report
+
+    async def delete(self, report_id: UUID) -> None:
+        self._store.pop(report_id, None)

--- a/app/services/defi/infrastructure/persistence/models.py
+++ b/app/services/defi/infrastructure/persistence/models.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import TSVECTOR, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ResearchReportModel(Base):
+
+    __tablename__ = "research_reports"
+
+    report_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+    )
+    slug: Mapped[str] = mapped_column(String(250), nullable=False, unique=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    body_markdown: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(String(500), nullable=False)
+    published_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    categories: Mapped[list[str]] = mapped_column(
+        Text, nullable=False
+    )
+    tags: Mapped[list[str]] = mapped_column(
+        Text, nullable=False
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    author_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    search_vector: Mapped[str] = mapped_column(
+        TSVECTOR(), nullable=False, server_default=text("''::tsvector")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )

--- a/app/services/defi/infrastructure/persistence/research_report_repository.py
+++ b/app/services/defi/infrastructure/persistence/research_report_repository.py
@@ -1,0 +1,154 @@
+import json
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert
+
+from ...domain.entities.research_report import ResearchReport
+from ...domain.interfaces.research_report_repository import IResearchReportRepository
+from .database import Database
+from .models import ResearchReportModel
+
+
+class PostgresResearchReportRepository(IResearchReportRepository):
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def get_by_id(self, report_id: UUID) -> Optional[ResearchReport]:
+        async with self._db.session() as session:
+            result = await session.execute(
+                select(ResearchReportModel).where(ResearchReportModel.report_id == report_id)
+            )
+            row = result.scalar_one_or_none()
+            return self._to_entity(row) if row else None
+
+    async def get_by_slug(self, slug: str) -> Optional[ResearchReport]:
+        async with self._db.session() as session:
+            result = await session.execute(
+                select(ResearchReportModel).where(ResearchReportModel.slug == slug)
+            )
+            row = result.scalar_one_or_none()
+            return self._to_entity(row) if row else None
+
+    async def list_by_category(self, category: str) -> list[ResearchReport]:
+        async with self._db.session() as session:
+            result = await session.execute(
+                select(ResearchReportModel).where(
+                    ResearchReportModel.categories.contains(category)
+                )
+            )
+            return [self._to_entity(row) for row in result.scalars().all()]
+
+    async def list_by_tag(self, tag: str) -> list[ResearchReport]:
+        async with self._db.session() as session:
+            result = await session.execute(
+                select(ResearchReportModel).where(
+                    ResearchReportModel.tags.contains(tag)
+                )
+            )
+            return [self._to_entity(row) for row in result.scalars().all()]
+
+    async def search_fts(self, query: str, limit: int = 20) -> list[ResearchReport]:
+        async with self._db.session() as session:
+            stmt = (
+                select(ResearchReportModel)
+                .where(
+                    ResearchReportModel.search_vector.op("@@")(
+                        func.plainto_tsquery("english", text(":query"))
+                    )
+                )
+                .order_by(
+                    func.ts_rank(
+                        ResearchReportModel.search_vector,
+                        func.plainto_tsquery("english", text(":query")),
+                    ).desc()
+                )
+                .limit(limit)
+            )
+            result = await session.execute(stmt, {"query": query})
+            return [self._to_entity(row) for row in result.scalars().all()]
+
+    async def upsert(self, report: ResearchReport) -> None:
+        now = datetime.now(tz=timezone.utc)
+        search_text = self._build_search_text(report)
+        stmt = (
+            insert(ResearchReportModel)
+            .values(
+                report_id=report.report_id,
+                slug=report.slug,
+                title=report.title,
+                body_markdown=report.body_markdown,
+                summary=report.summary,
+                published_at=report.published_at,
+                categories=json.dumps(report.categories),
+                tags=json.dumps(report.tags),
+                version=report.version,
+                author_type=report.author_type,
+                search_vector=search_text,
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["report_id"],
+                set_={
+                    "slug": report.slug,
+                    "title": report.title,
+                    "body_markdown": report.body_markdown,
+                    "summary": report.summary,
+                    "published_at": report.published_at,
+                    "categories": json.dumps(report.categories),
+                    "tags": json.dumps(report.tags),
+                    "version": report.version,
+                    "author_type": report.author_type,
+                    "search_vector": search_text,
+                    "updated_at": now,
+                },
+            )
+        )
+        async with self._db.session() as session:
+            await session.execute(stmt)
+
+    async def delete(self, report_id: UUID) -> None:
+        async with self._db.session() as session:
+            await session.execute(
+                ResearchReportModel.__table__.delete().where(
+                    ResearchReportModel.report_id == report_id
+                )
+            )
+
+    async def delete_by_slug(self, slug: str) -> None:
+        async with self._db.session() as session:
+            await session.execute(
+                ResearchReportModel.__table__.delete().where(
+                    ResearchReportModel.slug == slug
+                )
+            )
+
+    @staticmethod
+    def _build_search_text(report: ResearchReport) -> str:
+        parts = [
+            report.title,
+            report.summary,
+            report.body_markdown,
+            *report.categories,
+            *report.tags,
+        ]
+        return " ".join(parts)
+
+    @staticmethod
+    def _to_entity(row: ResearchReportModel) -> ResearchReport:
+        return ResearchReport(
+            report_id=row.report_id,
+            slug=row.slug,
+            title=row.title,
+            body_markdown=row.body_markdown,
+            summary=row.summary,
+            published_at=row.published_at,
+            categories=json.loads(row.categories),
+            tags=json.loads(row.tags),
+            version=row.version,
+            author_type=row.author_type,
+        )

--- a/migrations/defi/001_create_research_reports.sql
+++ b/migrations/defi/001_create_research_reports.sql
@@ -1,0 +1,66 @@
+-- Migration 001: Create research_reports table
+-- Service: defi
+-- Purpose: Persists impersonal, versioned market research reports.
+--          Includes a tsvector column for full-text search (FTS).
+-- Note: gen_random_uuid() is built-in since PostgreSQL 13. For older
+--       versions enable pgcrypto first: CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS research_reports (
+    report_id      UUID                        PRIMARY KEY,
+    slug           VARCHAR(250)                NOT NULL UNIQUE,
+    title          VARCHAR(200)                NOT NULL,
+    body_markdown  TEXT                        NOT NULL,
+    summary        VARCHAR(500)                NOT NULL,
+    published_at   TIMESTAMP WITH TIME ZONE    NOT NULL,
+    categories     TEXT                        NOT NULL,
+    tags           TEXT                        NOT NULL,
+    version        INTEGER                     NOT NULL DEFAULT 1,
+    author_type    VARCHAR(20)                 NOT NULL,
+    search_vector  TSVECTOR                    NOT NULL DEFAULT ''::tsvector,
+    created_at     TIMESTAMP WITH TIME ZONE    NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMP WITH TIME ZONE    NOT NULL DEFAULT NOW()
+);
+
+-- GIN index for full-text search on the tsvector column
+CREATE INDEX IF NOT EXISTS idx_research_reports_fts
+    ON research_reports
+    USING GIN (search_vector);
+
+-- Unique index for slug lookups
+CREATE UNIQUE INDEX IF NOT EXISTS idx_research_reports_slug
+    ON research_reports (slug);
+
+-- Index for filtering by author type
+CREATE INDEX IF NOT EXISTS idx_research_reports_author_type
+    ON research_reports (author_type);
+
+-- Index for filtering by publication date
+CREATE INDEX IF NOT EXISTS idx_research_reports_published_at
+    ON research_reports (published_at DESC);
+
+-- Trigger to keep search_vector in sync with title, summary, body, categories, tags
+CREATE OR REPLACE FUNCTION research_reports_search_vector_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.search_vector :=
+        setweight(to_tsvector('english', NEW.title), 'A') ||
+        setweight(to_tsvector('english', NEW.summary), 'B') ||
+        setweight(to_tsvector('english', NEW.body_markdown), 'C') ||
+        setweight(to_tsvector('english', NEW.categories), 'D') ||
+        setweight(to_tsvector('english', NEW.tags), 'D');
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_research_reports_search_vector
+    BEFORE INSERT OR UPDATE ON research_reports
+    FOR EACH ROW
+    EXECUTE FUNCTION research_reports_search_vector_update();
+
+COMMENT ON TABLE  research_reports IS 'Impersonal, versioned market research reports. No user-specific or personalized content.';
+COMMENT ON COLUMN research_reports.report_id     IS 'UUID v4 — application-generated (never user-derived).';
+COMMENT ON COLUMN research_reports.author_type    IS 'editorial | automated — never "user".';
+COMMENT ON COLUMN research_reports.search_vector  IS 'tsvector for full-text search across title, summary, body, categories, tags.';
+COMMENT ON COLUMN research_reports.categories     IS 'JSON-encoded array of category strings.';
+COMMENT ON COLUMN research_reports.tags           IS 'JSON-encoded array of tag strings.';

--- a/tests/defi/test_research_report.py
+++ b/tests/defi/test_research_report.py
@@ -1,0 +1,315 @@
+import sys
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from app.services.defi.domain.entities.research_report import ResearchReport
+from app.services.defi.application.research_report_service import ResearchReportService
+from app.services.defi.domain.exceptions import ResearchReportNotFoundError
+from app.services.defi.infrastructure.persistence.in_memory_research_report_repository import (
+    InMemoryResearchReportRepository,
+)
+
+
+def _valid_payload(**overrides) -> dict:
+    base = {
+        "report_id": str(uuid4()),
+        "title": "Q3 2024 DeFi Market Overview",
+        "body_markdown": "# Market Report\n\nThe DeFi market has shown resilience...",
+        "summary": "Q3 2024 saw a 12% increase in TVL across major protocols.",
+        "published_at": datetime.now(tz=timezone.utc).isoformat(),
+        "categories": ["market-analysis", "tvl"],
+        "tags": ["defi", "ethereum", "tvl"],
+        "version": 1,
+        "author_type": "editorial",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Entity: field validation
+# ---------------------------------------------------------------------------
+
+def test_entity_accepts_valid_payload():
+    report = ResearchReport.model_validate(_valid_payload())
+    assert report.title == "Q3 2024 DeFi Market Overview"
+    assert report.author_type == "editorial"
+    assert report.version == 1
+
+
+def test_entity_rejects_user_id_in_payload():
+    payload = _valid_payload(user_id=str(uuid4()))
+    with pytest.raises(ValidationError) as exc_info:
+        ResearchReport.model_validate(payload)
+    assert "user_id" in str(exc_info.value)
+
+
+def test_entity_rejects_author_type_user():
+    payload = _valid_payload(author_type="user")
+    with pytest.raises(ValidationError) as exc_info:
+        ResearchReport.model_validate(payload)
+    assert "author_type" in str(exc_info.value) or "user" in str(exc_info.value)
+
+
+def test_entity_accepts_automated_author_type():
+    payload = _valid_payload(author_type="automated")
+    report = ResearchReport.model_validate(payload)
+    assert report.author_type == "automated"
+
+
+def test_entity_rejects_title_over_200_chars():
+    payload = _valid_payload(title="x" * 201)
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_rejects_summary_over_500_chars():
+    payload = _valid_payload(summary="x" * 501)
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_rejects_blank_title():
+    payload = _valid_payload(title="   ")
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_rejects_empty_categories():
+    payload = _valid_payload(categories=[])
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_rejects_empty_tags():
+    payload = _valid_payload(tags=[])
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_rejects_version_zero():
+    payload = _valid_payload(version=0)
+    with pytest.raises(ValidationError):
+        ResearchReport.model_validate(payload)
+
+
+def test_entity_is_frozen():
+    report = ResearchReport.model_validate(_valid_payload())
+    with pytest.raises(Exception):
+        report.title = "changed"
+
+
+def test_entity_auto_generates_slug_from_title():
+    report = ResearchReport.model_validate(_valid_payload())
+    assert report.slug == "q3-2024-defi-market-overview"
+
+
+def test_entity_accepts_explicit_slug():
+    payload = _valid_payload(slug="my-custom-slug")
+    report = ResearchReport.model_validate(payload)
+    assert report.slug == "my-custom-slug"
+
+
+# ---------------------------------------------------------------------------
+# Entity: forbidden fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("forbidden_field", ["user_id", "wallet_address", "subscriber_id", "personalized_for"])
+def test_entity_rejects_all_forbidden_fields(forbidden_field):
+    payload = _valid_payload(**{forbidden_field: "forbidden_value"})
+    with pytest.raises(ValidationError) as exc_info:
+        ResearchReport.model_validate(payload)
+    assert forbidden_field in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Service: publish guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_service_publish_rejects_user_id():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(user_id=str(uuid4()))
+    with pytest.raises((ValueError, ValidationError)) as exc_info:
+        await service.publish(payload)
+    assert "user_id" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_service_publish_rejects_wallet_address():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(wallet_address="0x1234")
+    with pytest.raises((ValueError, ValidationError)):
+        await service.publish(payload)
+
+
+@pytest.mark.asyncio
+async def test_service_publish_rejects_subscriber_id():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(subscriber_id="sub_123")
+    with pytest.raises((ValueError, ValidationError)):
+        await service.publish(payload)
+
+
+@pytest.mark.asyncio
+async def test_service_publish_rejects_personalized_for():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(personalized_for="user_abc")
+    with pytest.raises((ValueError, ValidationError)):
+        await service.publish(payload)
+
+
+@pytest.mark.asyncio
+async def test_service_publish_rejects_author_type_user():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(author_type="user")
+    with pytest.raises((ValueError, ValidationError)):
+        await service.publish(payload)
+
+
+@pytest.mark.asyncio
+async def test_service_publish_succeeds_with_valid_payload():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload()
+    report = await service.publish(payload)
+    assert report.report_id is not None
+    stored = await repo.get_by_id(report.report_id)
+    assert stored is not None
+    assert stored.title == report.title
+
+
+@pytest.mark.asyncio
+async def test_service_publish_does_not_store_user_id():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    payload = _valid_payload(user_id=str(uuid4()))
+    try:
+        await service.publish(payload)
+    except (ValueError, ValidationError):
+        pass
+    assert len(repo._store) == 0
+
+
+# ---------------------------------------------------------------------------
+# Service: get / list / search / delete
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_service_get_by_id_returns_report():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    report = await service.publish(_valid_payload())
+    fetched = await service.get_by_id(report.report_id)
+    assert fetched.title == report.title
+
+
+@pytest.mark.asyncio
+async def test_service_get_by_id_raises_not_found():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    with pytest.raises(ResearchReportNotFoundError):
+        await service.get_by_id(uuid4())
+
+
+@pytest.mark.asyncio
+async def test_service_list_by_category():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    await service.publish(_valid_payload())
+    await service.publish(_valid_payload(
+        report_id=str(uuid4()),
+        categories=["staking", "yields"],
+    ))
+    results = await service.list_by_category("staking")
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_service_list_by_tag():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    await service.publish(_valid_payload())
+    results = await service.list_by_tag("ethereum")
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_service_search_fts():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    await service.publish(_valid_payload(
+        title="Ethereum Staking Yields Q3",
+        body_markdown="Ethereum staking has yielded strong returns...",
+        tags=["ethereum", "staking"],
+    ))
+    await service.publish(_valid_payload(
+        report_id=str(uuid4()),
+        title="Solana Ecosystem Growth",
+        body_markdown="Solana has grown rapidly...",
+        tags=["solana", "ecosystem"],
+    ))
+    results = await service.search("ethereum")
+    assert len(results) == 1
+    assert "Ethereum" in results[0].title
+
+
+@pytest.mark.asyncio
+async def test_service_search_fts_no_results():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    await service.publish(_valid_payload())
+    results = await service.search("nonexistent_term_xyz")
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_service_delete_removes_report():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    report = await service.publish(_valid_payload())
+    await service.delete(report.report_id)
+    fetched = await repo.get_by_id(report.report_id)
+    assert fetched is None
+
+
+# ---------------------------------------------------------------------------
+# Service: slug-based operations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_service_get_by_slug_returns_report():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    report = await service.publish(_valid_payload())
+    fetched = await service.get_by_slug(report.slug)
+    assert fetched.title == report.title
+
+
+@pytest.mark.asyncio
+async def test_service_get_by_slug_raises_not_found():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    with pytest.raises(ResearchReportNotFoundError):
+        await service.get_by_slug("nonexistent-slug")
+
+
+@pytest.mark.asyncio
+async def test_service_delete_by_slug_removes_report():
+    repo = InMemoryResearchReportRepository()
+    service = ResearchReportService(repository=repo)
+    report = await service.publish(_valid_payload())
+    await service.delete_by_slug(report.slug)
+    fetched = await repo.get_by_slug(report.slug)
+    assert fetched is None


### PR DESCRIPTION
feat(#88): Building ResearchReport entity

## Summary by Sourcery

Introduce an impersonal DeFi research report domain model, persistence layer, service, and HTTP API, wired into the FastAPI application lifecycle.

New Features:
- Add ResearchReport domain entity with validation to enforce impersonal, non-user-specific research content.
- Add ResearchReportService and repository abstractions with in-memory and PostgreSQL-backed implementations, including full-text search support.
- Expose REST endpoints for publishing, listing, searching, retrieving, and deleting research reports via a new /v1/defi/research router.

Enhancements:
- Wire the research report service into the FastAPI app lifespan and dependency injection, and extend DeFi exception handling with a ResearchReportNotFoundError.
- Add database models, async database helper, and SQL migration for the research_reports table with FTS indexes and triggers.
- Extend public API schema exports and domain/interface registries to include research report types.

Tests:
- Add unit and service-level tests covering ResearchReport validation, publish safeguards, repository behavior, and search/list/delete operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeFi research reports with publishing, retrieval, deletion, category/tag filtering, and full-text search.
  * Added automatic slug generation and validation for report content, metadata, and authorship.
  * Added persistent storage support and database migration for research reports.
  * Added API validation and clear not-found responses.
* **Tests**
  * Added comprehensive coverage for report validation, search, filtering, publishing, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->