### PR TITLE
feat(#66): GET /defi/rankings/protocols via DeFiLlama

### DIFF
--- a/app/services/defi/infrastructure/cache/redis_cache.py
+++ b/app/services/defi/infrastructure/cache/redis_cache.py
@@ -1,0 +1,43 @@
+import json
+import os
+from datetime import datetime, timedelta
+
+import redis
+from redis.asyncio import Redis
+
+REDIS_URL = os.getenv("CACHE_URL", "redis://localhost:6379/1")
+
+__all__ = ["get", "set"]
+
+
+_redis_client: Redis | None = None
+
+
+def get_redis() -> Redis:
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+async def get(key: str) -> Optional[Any]:
+    try:
+        r = get_redis()
+        value = r.get(key)
+        if value is None:
+            return None
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    except (redis.ConnectionError, redis.TimeoutError):
+        return None
+
+
+async def set(key: str, value: Any, ttl: int = 300) -> None:
+    try:
+        r = get_redis()
+        serialized = json.dumps(value, default=str)
+        r.setex(key, ttl, serialized)
+    except (redis.ConnectionError, redis.TimeoutError):
+        pass

--- a/app/services/defi/infrastructure/market_data/defillama_adapter.py
+++ b/app/services/defi/infrastructure/market_data/defillama_adapter.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List, Optional
+
+import httpx
+from datetime import datetime, timedelta
+
+from app.services.defi.infrastructure.cache.redis_cache import get, set
+
+
+class DeFiLlamaAdapter:
+    BASE_URL = "https://api.llama.fi"
+
+    def __init__(self, client: Optional[httpx.AsyncClient] = None) -> None:
+        self._client = client or httpx.AsyncClient(base_url=self.BASE_URL, timeout=30.0)
+
+    async def _get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        cache_key = f"defillama:{endpoint}"
+        cached = await get(cache_key)
+        if cached is not None:
+            return cached
+
+        response = await self._client.get(endpoint, params=params)
+        response.raise_for_status()
+        data = response.json()
+        await set(cache_key, data, ttl=900)
+        return data
+
+    async def get_protocols(self) -> List[Dict[str, Any]]:
+        data = await self._get("/protocols")
+        return data.get("data", []) or []
+
+    async def get_historical_chain_tvl(self, chain: str) -> List[Dict[str, Any]]:
+        data = await self._get(f"/v2/historicalChainTvl/{chain}")
+        return data.get("data", []) or []

--- a/tests/test_defillama_adapter.py
+++ b/tests/test_defillama_adapter.py
@@ -1,0 +1,43 @@
+import asyncio
+import respx
+from app.services.defi.infrastructure.market_data.defillama_adapter import DeFiLlamaAdapter
+
+
+def test_get_protocols() -> None:
+    with respx.mock:
+        respx.get("https://api.llama.fi/protocols").respond(
+            200,
+            json={
+                "data": [
+                    {"name": "Uniswap", "symbol": "UNI", "tvl": 4_000_000_000},
+                    {"name": "Aave", "symbol": "AAVE", "tvl": 2_500_000_000},
+                ]
+            },
+        )
+
+        adapter = DeFiLlamaAdapter()
+        protocols = asyncio.run(adapter.get_protocols())
+        assert len(protocols) == 2
+        assert protocols[0]["name"] == "Uniswap"
+        assert protocols[0]["tvl"] == 4_000_000_000
+        assert protocols[1]["name"] == "Aave"
+        assert protocols[1]["tvl"] == 2_500_000_000
+
+
+def test_get_historical_chain_tvl() -> None:
+    with respx.mock:
+        respx.get("https://api.llama.fi/v2/historicalChainTvl/eth").respond(
+            200,
+            json={
+                "data": [
+                    {"timestamp": 1700000000, "tvl": 3_500_000_000},
+                    {"timestamp": 1700100000, "tvl": 3_600_000_000},
+                ]
+            },
+        )
+
+        adapter = DeFiLlamaAdapter()
+        data = asyncio.run(adapter.get_historical_chain_tvl("eth"))
+        assert len(data) == 2
+        assert data[0]["tvl"] == 3_500_000_000
+        assert data[1]["tvl"] == 3_600_000_000


### PR DESCRIPTION
feat(#66): GET /defi/rankings/protocols via DeFiLlama

## Summary by Sourcery

Integrate DeFiLlama data access with resilient caching for DeFi market information.

New Features:
- Add DeFiLlama market-data integration for protocol rankings and historical chain TVL retrieval.

Enhancements:
- Add Redis-backed caching for external DeFiLlama responses with graceful fallback when Redis is unavailable.

Tests:
- Add coverage for protocol and historical chain TVL retrieval from DeFiLlama.